### PR TITLE
Increase upload limits

### DIFF
--- a/inventory/awspilot/group_vars/webserver/apache.yml
+++ b/inventory/awspilot/group_vars/webserver/apache.yml
@@ -1,5 +1,7 @@
 ---
-
+php_upload_max_filesize: 1024M
+php_post_max_size: 1024M
+php_max_execution_time: 300
 apache_listen_port: 8000
 apache_create_vhosts: true
 apache_vhosts_filename: "islandora.conf"

--- a/inventory/docker/group_vars/webserver/apache.yml
+++ b/inventory/docker/group_vars/webserver/apache.yml
@@ -1,5 +1,7 @@
 ---
-
+php_upload_max_filesize: 1024M
+php_post_max_size: 1024M
+php_max_execution_time: 300
 apache_listen_port: 8000
 apache_create_vhosts: true
 apache_vhosts_filename: "islandora.conf"

--- a/webserver.yml
+++ b/webserver.yml
@@ -3,9 +3,6 @@
 - hosts: webserver
   become: yes
 
-  pre_tasks:
-    - include_vars: msel/varfile.yml
-
   vars:
     php_version: "7.2"
 


### PR DESCRIPTION
The default 64MB is not usable.  1024 is more than enough for uploading
the proof-of-concept materials.  In production, we should consider installing the plupload module, rather than increasing the upload limit