### PR TITLE
Point cantaloupe to the right server

### DIFF
--- a/inventory/awspilot/group_vars/webserver/general.yml
+++ b/inventory/awspilot/group_vars/webserver/general.yml
@@ -2,4 +2,4 @@
 
 webserver_app: yes
 openseadragon_iiiv_set_var: yes
-openseadragon_iiiv_server: http://localhost:8080/cantaloupe/iiif/2
+openseadragon_iiiv_server: http://i8p.cloud.library.jhu.edu:8080/cantaloupe/iiif/2


### PR DESCRIPTION
Right now, the Openseadragon viewer doesn't work, as it is configured to connect to an IIIF server on localhost instead of the pilot instance.  This should hopefully fix that issue.

Additionally, @derekbelrose can you enable port 8080, so that the IIIF server is accessible to browsers?  If you want to lock it down as much as possible (not sure if there is a proxy), it's at /cantaloupe